### PR TITLE
feat: nest user data fields in 'data' property

### DIFF
--- a/pr-description.md
+++ b/pr-description.md
@@ -1,0 +1,37 @@
+## Breaking Change
+
+Annotation and arrow target data values are now nested under a `data` property to prevent field name collisions with library internal fields like `id`, `dx`, `dy`, `text`, etc.
+
+### Before
+
+```javascript
+// Annotation
+{ id: 0, myX: 1995, myY: 5, dx: 0, dy: 0, text: '...', arrows: [...] }
+
+// Arrow target
+{ target: { myX: 2010, myY: 4.5, dx: 0, dy: 0 } }
+```
+
+### After
+
+```javascript
+// Annotation
+{ id: 0, data: { myX: 1995, myY: 5 }, dx: 0, dy: 0, text: '...', arrows: [...] }
+
+// Arrow target
+{ target: { data: { myX: 2010, myY: 4.5 }, dx: 0, dy: 0 } }
+```
+
+### Why
+
+This prevents issues when user datasets have fields named `id`, `dx`, `dy`, `text`, `width`, `arrows`, etc. that would collide with the annotation library's internal fields.
+
+### Changes
+
+- Updated `Annotation` and `ArrowTarget` interfaces in `types.d.ts`
+- Updated coordinate utilities to read from `.data` property
+- Updated components (`AnnotationsData.svelte`, `AnnotationEditor.svelte`, `ArrowZone.svelte`)
+- Updated `newAnnotation.js` factory
+- Updated demo page data structures
+- Updated README documentation
+

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -38,8 +38,10 @@ src/lib/
 ```typescript
 {
   id: number,              // Unique identifier
-  [xKey]: any,             // X data value (key from LayerCake config)
-  [yKey]: any,             // Y data value (key from LayerCake config)
+  data: {                  // User data values (nested to avoid key collisions)
+    [xKey]: any,           // X data value (key from LayerCake config)
+    [yKey]: any            // Y data value (key from LayerCake config)
+  },
   dx: number,              // X offset: -100 to 100 (percentage of chart width)
   dy: number,              // Y offset: -100 to 100 (percentage of chart height)
   text: string,            // Annotation text (supports line breaks)
@@ -62,8 +64,10 @@ src/lib/
     dy: number             // Pixels from annotation vertical center
   },
   target: {
-    [xKey]: any,           // X data value (same accessor as LayerCake)
-    [yKey]: any,           // Y data value
+    data: {                // User data values (nested to avoid key collisions)
+      [xKey]: any,         // X data value (same accessor as LayerCake)
+      [yKey]: any          // Y data value
+    },
     dx?: number,           // 0-100: % offset within ordinal band (X)
     dy?: number            // 0-100: % offset within ordinal band (Y)
   }
@@ -77,13 +81,13 @@ The library uses multiple coordinate systems:
 ### Annotation Position
 
 ```
-Final position = scale(dataValue) + (dx/100 × chartDimension)
+Final position = scale(data[key]) + (dx/100 × chartDimension)
 ```
 
 | Property | Unit | Range | Example |
 |----------|------|-------|---------|
-| `[xKey]` | Data value | Depends on data | `new Date('2024-01-15')` |
-| `[yKey]` | Data value | Depends on data | `42` |
+| `data.[xKey]` | Data value | Depends on data | `new Date('2024-01-15')` |
+| `data.[yKey]` | Data value | Depends on data | `42` |
 | `dx` | % of chart width | -100 to 100 | `5` = 5% right |
 | `dy` | % of chart height | -100 to 100 | `-10` = 10% up |
 
@@ -100,7 +104,7 @@ Pixels relative to annotation box edge:
 
 | Property | Unit | When used |
 |----------|------|-----------|
-| `[xKey]`, `[yKey]` | Data values | Always (same keys as LayerCake config) |
+| `data.[xKey]`, `data.[yKey]` | Data values | Always (same keys as LayerCake config) |
 | `dx`, `dy` | % within band (0-100) | Only for ordinal scales |
 
 ## Keyboard Shortcuts

--- a/src/lib/components/AnnotationEditor.svelte
+++ b/src/lib/components/AnnotationEditor.svelte
@@ -41,8 +41,8 @@
 	/**
 	 * Coordinates
 	 */
-	let left = $derived(`calc(${$xGet(d)}${units} + ${d.dx}%)`);
-	let top = $derived(`calc(${$yGet(d)}${units} + ${d.dy}%)`);
+	let left = $derived(`calc(${$xGet(d.data)}${units} + ${d.dx}%)`);
+	let top = $derived(`calc(${$yGet(d.data)}${units} + ${d.dy}%)`);
 
 	/**
 	 * @param {Array} [position] - The x and y pixel coordinates of the draggable element.
@@ -52,14 +52,24 @@
 		const xVal = x ? invertScale($xScale, x) : [];
 		const yVal = y ? invertScale($yScale, y) : [];
 
-		const newProps = filterObject(
+		// Build data object only if we have new values
+		const newData = filterObject(
 			{
 				[$config.x]: xVal[0],
-				[$config.y]: yVal[0],
+				[$config.y]: yVal[0]
+			},
+			(val) => val !== undefined
+		);
+
+		/** @type {Record<string, unknown>} */
+		const newProps = filterObject(
+			{
+				// Only include data if it has values (avoid overwriting with empty object)
+				data: Object.keys(newData).length > 0 ? newData : undefined,
 				dx: xVal[1],
 				dy: yVal[1]
 			},
-			(d) => d !== undefined
+			(val) => val !== undefined
 		);
 
 		// Always save current width

--- a/src/lib/components/AnnotationEditor.svelte
+++ b/src/lib/components/AnnotationEditor.svelte
@@ -58,7 +58,7 @@
 				[$config.x]: xVal[0],
 				[$config.y]: yVal[0]
 			},
-			(val) => val !== undefined
+			(d) => d !== undefined
 		);
 
 		/** @type {Record<string, unknown>} */
@@ -69,7 +69,7 @@
 				dx: xVal[1],
 				dy: yVal[1]
 			},
-			(val) => val !== undefined
+			(d) => d !== undefined
 		);
 
 		// Always save current width

--- a/src/lib/components/AnnotationEditor.svelte
+++ b/src/lib/components/AnnotationEditor.svelte
@@ -52,9 +52,10 @@
 		const xVal = x ? invertScale($xScale, x) : [];
 		const yVal = y ? invertScale($yScale, y) : [];
 
-		// Build data object only if we have new values
+		// Build data object, preserving existing values and overlaying new ones
 		const newData = filterObject(
 			{
+				...d.data,
 				[$config.x]: xVal[0],
 				[$config.y]: yVal[0]
 			},

--- a/src/lib/components/AnnotationsData.svelte
+++ b/src/lib/components/AnnotationsData.svelte
@@ -21,8 +21,8 @@
 		<div
 			class="static-wrapper"
 			data-id={i}
-			style:left={`calc(${$xGet(d)}${units} + ${d.dx || 0}%)`}
-			style:top={`calc(${$yGet(d)}${units} + ${d.dy || 0}%)`}
+			style:left={`calc(${$xGet(d.data)}${units} + ${d.dx || 0}%)`}
+			style:top={`calc(${$yGet(d.data)}${units} + ${d.dy || 0}%)`}
 			style:width={d.width}
 		>
 			<div class="layercake-annotation {d.class || ''}" style={d.style} style:text-align={d.align || 'left'}>

--- a/src/lib/components/ArrowZone.svelte
+++ b/src/lib/components/ArrowZone.svelte
@@ -217,8 +217,10 @@
 					clockwise,
 					source: { dx: newSourceDx, dy: newSourceDy },
 					target: {
-						[$config.x]: targetDataX,
-						[$config.y]: targetDataY,
+						data: {
+							[$config.x]: targetDataX,
+							[$config.y]: targetDataY
+						},
 						dx: targetOffsetX,
 						dy: targetOffsetY
 					}
@@ -242,8 +244,10 @@
 					dy: arrow?.source?.dy ?? defaultSourceDy
 				},
 				target: {
-					[$config.x]: targetDataX,
-					[$config.y]: targetDataY,
+					data: {
+						[$config.x]: targetDataX,
+						[$config.y]: targetDataY
+					},
 					dx: targetOffsetX,
 					dy: targetOffsetY
 				}

--- a/src/lib/modules/coordinates.js
+++ b/src/lib/modules/coordinates.js
@@ -37,9 +37,9 @@ export function getAnnotationBox(anno, scales) {
 	const offsetX = ((anno.dx ?? 0) / 100) * width;
 	const offsetY = ((anno.dy ?? 0) / 100) * height;
 
-	// Calculate top-left position
-	const left = xScale(x(anno)) + offsetX;
-	const top = yScale(y(anno)) + offsetY;
+	// Calculate top-left position (data values are nested in anno.data)
+	const left = xScale(x(anno.data)) + offsetX;
+	const top = yScale(y(anno.data)) + offsetY;
 
 	// Get width (stored as "150px" string or use default)
 	const annoWidth = anno.width ? parseInt(anno.width) : DEFAULT_ANNOTATION_WIDTH;
@@ -90,9 +90,9 @@ export function getArrowSource(anno, arrow, scales, annoHeight = 0) {
 export function getArrowTarget(arrow, scales) {
 	const { xScale, yScale, x, y, width, height } = scales;
 
-	// Target is in data space
-	const baseX = xScale(x(arrow.target));
-	const baseY = yScale(y(arrow.target));
+	// Target is in data space (data values are nested in arrow.target.data)
+	const baseX = xScale(x(arrow.target.data));
+	const baseY = yScale(y(arrow.target.data));
 
 	// Add percentage offsets (used for ordinal scales)
 	const offsetX = ((arrow.target?.dx ?? 0) / 100) * width;

--- a/src/lib/modules/newAnnotation.js
+++ b/src/lib/modules/newAnnotation.js
@@ -15,8 +15,10 @@ export default function newAnnotation(e, id, { xScale, yScale, config }) {
 
 	return {
 		id,
-		[config.x]: xVal[0],
-		[config.y]: yVal[0],
+		data: {
+			[config.x]: xVal[0],
+			[config.y]: yVal[0]
+		},
 		dx: xVal[1],
 		dy: yVal[1],
 		text: 'New note...',

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -16,9 +16,8 @@ export interface ArrowSource {
  * Arrow target position (data space coordinates)
  */
 export interface ArrowTarget {
-	/** X data value (key varies based on LayerCake config) */
-	[xKey: string]: unknown;
-	/** Y data value (key varies based on LayerCake config) */
+	/** User data values (x/y keys match LayerCake config) */
+	data: Record<string, unknown>;
 	/** Percentage offset for ordinal X scales (0-100) */
 	dx?: number;
 	/** Percentage offset for ordinal Y scales (0-100) */
@@ -45,9 +44,8 @@ export interface Arrow {
 export interface Annotation {
 	/** Unique identifier */
 	id: number;
-	/** X data value (key varies based on LayerCake config, e.g., 'date' or 'x') */
-	[xKey: string]: unknown;
-	/** Y data value (key varies based on LayerCake config, e.g., 'value' or 'y') */
+	/** User data values (x/y keys match LayerCake config) */
+	data: Record<string, unknown>;
 	/** Percentage offset from data point in X direction */
 	dx: number;
 	/** Percentage offset from data point in Y direction */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,8 +38,7 @@
 	let lineAnnotations = $state([
 		{
 			id: 0,
-			myX: 1995,
-			myY: 5,
+			data: { myX: 1995, myY: 5 },
 			dx: 0,
 			dy: 0,
 			text: 'Annotation text',
@@ -49,7 +48,7 @@
 					side: 'east',
 					clockwise: true,
 					source: { dx: 0, dy: 10 },
-					target: { myX: 2010, myY: 4.5, dx: 0, dy: 0 }
+					target: { data: { myX: 2010, myY: 4.5 }, dx: 0, dy: 0 }
 				}
 			]
 		}
@@ -58,8 +57,7 @@
 	let columnAnnotations = $state([
 		{
 			id: 0,
-			year: '1981',
-			value: 8,
+			data: { year: '1981', value: 8 },
 			dx: 0,
 			dy: 0,
 			text: 'Annotation text',
@@ -69,7 +67,7 @@
 					side: 'east',
 					clockwise: true,
 					source: { dx: 0, dy: 10 },
-					target: { year: '1982', value: 8.5, dx: 0, dy: 0 }
+					target: { data: { year: '1982', value: 8.5 }, dx: 0, dy: 0 }
 				}
 			]
 		}


### PR DESCRIPTION
## Breaking Change

Annotation and arrow target data values are now nested under a `data` property to prevent field name collisions with library internal fields like `id`, `dx`, `dy`, `text`, etc.

### Before

```javascript
// Annotation
{ id: 0, myX: 1995, myY: 5, dx: 0, dy: 0, text: '...', arrows: [...] }

// Arrow target
{ target: { myX: 2010, myY: 4.5, dx: 0, dy: 0 } }
```

### After

```javascript
// Annotation
{ id: 0, data: { myX: 1995, myY: 5 }, dx: 0, dy: 0, text: '...', arrows: [...] }

// Arrow target
{ target: { data: { myX: 2010, myY: 4.5 }, dx: 0, dy: 0 } }
```

### Why

This prevents issues when user datasets have fields named `id`, `dx`, `dy`, `text`, `width`, `arrows`, etc. that would collide with the annotation library's internal fields.

### Changes

- Updated `Annotation` and `ArrowTarget` interfaces in `types.d.ts`
- Updated coordinate utilities to read from `.data` property
- Updated components (`AnnotationsData.svelte`, `AnnotationEditor.svelte`, `ArrowZone.svelte`)
- Updated `newAnnotation.js` factory
- Updated demo page data structures
- Updated README documentation

